### PR TITLE
Hardcode specific version of deps for example app

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,22 +1,26 @@
 turnkey-asp-net-core-16.0 (1) turnkey; urgency=low
 
-  * Initial release of ASP.NET
+  * Initial release of asp-net-core appliance.
 
   * Built on (currently) stable Debian 10 Buster
+
+  * Includes TurnKey "example app". (Note not using latest version of
+    asp-net-core as the MySQL/MariaDB connector we use does not yet have a
+    stable release compatible with asp-net-core v5.x (now part of dot-net v5).
 
   * Major component versions
  
     (debian repos)
     nginx                   1.14.2-2
-    webmin                  1.930-turnkey+21
+    webmin                  1.941-turnkey+2
     shellinabox             2.21
 
     (microsoft repos)
-    dotnet-runtime-3.1      3.1.1-1
-    dotnet-sdk-3.1          3.1.101-1
-    aspnetcore-runtime-3.1  3.1.1-1
+    dotnet-runtime-3.1      3.1.10-1
+    dotnet-sdk-3.1          3.1.404-1
+    aspnetcore-runtime-3.1  3.1.10-1
 
   * Note please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
 
- -- Stefan Davis <stefan@turnkeylinux>  Thu, 5 Feb 2020 17:49:06 +1100
+ -- Stefan Davis <stefan@turnkeylinux.org>  Mon, 23 Nov 2020 10:27:52 +1100

--- a/conf.d/main
+++ b/conf.d/main
@@ -46,17 +46,19 @@ su - aspnet << "EOF"
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 APP_SRC_ROOT='/var/www/aspnetcore-src'
 APP_ROOT='/var/www/aspnetcore'
+DNV=3.1.4 # DOTNET VERSION
 
 dotnet tool install --global dotnet-ef
-dotnet tool install --global dotnet-aspnet-codegenerator
+# https://www.nuget.org/packages/dotnet-aspnet-codegenerator/
+dotnet tool install --global dotnet-aspnet-codegenerator --version $DNV
 
 cd /var/www
 dotnet new webapp -o aspnetcore-src -n 'TurnkeyExampleApp'
 cd aspnetcore-src
-dotnet add package Microsoft.EntityFrameworkCore.Design
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.Extensions.Logging.Debug
+dotnet add package Microsoft.EntityFrameworkCore.Design --version $DNV
+dotnet add package Microsoft.EntityFrameworkCore.Tools --version $DNV
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version $DNV
+dotnet add package Microsoft.Extensions.Logging.Debug --version $DNV
 dotnet add package Pomelo.EntityFrameworkCore.MySql
 
 # copy aspnet site source (minus project data)

--- a/conf.d/main
+++ b/conf.d/main
@@ -59,6 +59,9 @@ dotnet add package Microsoft.EntityFrameworkCore.Design --version $DNV
 dotnet add package Microsoft.EntityFrameworkCore.Tools --version $DNV
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version $DNV
 dotnet add package Microsoft.Extensions.Logging.Debug --version $DNV
+
+# next build; check for dot-net v5 compatible release of this:
+# https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql/
 dotnet add package Pomelo.EntityFrameworkCore.MySql
 
 # copy aspnet site source (minus project data)


### PR DESCRIPTION
Note a new version of asp-net-core has been released v5.0.0. As of this
release, asp-net-core is a part of dot-net, so to get asp-net-core, you
need to install dot-net v5.0.0.

The dependency which we provide to link asp-net-core to MySQL/MariaDB
does not yet have a stable release compatible with v5.

https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql/